### PR TITLE
Remove task number from Nomad container name

### DIFF
--- a/message.go
+++ b/message.go
@@ -99,6 +99,7 @@ var docker_left_names = [...]string{
 }
 
 var allocIdRegex = regexp.MustCompile(`-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+var taskNumberRegex = regexp.MustCompile(`-\d+$`)
 
 func JSONToMessage(str string) Message {
 	//fmt.Printf("JSONToMessage: %+v\n", str)
@@ -215,6 +216,9 @@ func EnsureMessageService(m *Message) error {
 		if ok {
 			if allocIdRegex.MatchString(container_name) {
 				service = container_name[0:allocIdRegex.FindStringIndex(container_name)[0]]
+				if taskNumberRegex.MatchString(service) {
+					service = service[0:taskNumberRegex.FindStringIndex(service)[0]]
+				}
 				m.Container.Set(service, "service")
 				m.Topic = service
 			} else {


### PR DESCRIPTION
Since we need to run jobs that require autoscaling in AWS as system jobs which can only have task groups with count = 1, we need to have multiple tasks in case we want to run multiple containers. So the number has to be appended to the task name to make logging work. This removes the number so logs are sent to the correct topic.